### PR TITLE
Add mongos_no_http_interface variable

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -6,3 +6,4 @@ mongos_port: 2900
 mongoc_port: 2800
 mongoc_servers: [vm1, vm2]
 mongos_chunk_size: 1
+mongos_no_http_interface: false

--- a/templates/mongos.conf.j2
+++ b/templates/mongos.conf.j2
@@ -11,6 +11,7 @@ logappend=true
 # fork and run in background
 fork = true
 
+nohttpinterface = {{ mongos_no_http_interface }}
 port = {{ mongos_port }}
 {% set hosts = '' %}
  {% for host in mongoc_servers %}


### PR DESCRIPTION
Allows for enabling or disabling mongos's HTTP interface with
`mongos_no_http_interface`. By default, this variable is set to
'false', which enables the interface.
