### PR TITLE
Fixes for ansible 2.0

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -32,7 +32,7 @@
   user: name={{ mongo_user }} comment="MongoD"
 
 - name: make sure the hostname is available in /etc/hosts
-  lineinfile: dest=/etc/hosts regexp="{{ ansible_hostname }}" line="{{ hostvars[inventory_hostname].ansible_default_ipv4.address + " " + ansible_hostname }}" state=present
+  lineinfile: dest=/etc/hosts regexp="{{ ansible_hostname }}" line="{{ hostvars[inventory_hostname].ansible_default_ipv4.address + ' ' + ansible_hostname }}" state=present
 
 - name: Install the mongodb package
   yum: name={{ item }} state=installed


### PR DESCRIPTION
Using double quotes in lineinfile gives this error with ansible 2.0 and above
`ERROR! this task 'lineinfile' has extra params, which is only allowed in the following modules: command, shell, script, include, include_vars, add_host, group_by, set_fact, raw, meta`
